### PR TITLE
Random subnet fix

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -71,9 +71,7 @@ resource "random_id" "index" {
 }
 
 locals {
-  subnet_ids_list         = tolist(data.aws_subnets.public.ids)                       // used for a random subnet
-  subnet_ids_random_index = random_id.index.dec % length(data.aws_subnets.public.ids) // used for a random subnet
-  instance_subnet_id      = local.subnet_ids_list[local.subnet_ids_random_index]      // used for a random subnet
+  subnet_ids_list = tolist(data.aws_subnets.public.ids) // used to distrubute nodes in subnets
 }
 
 // Create etcd instances
@@ -102,7 +100,7 @@ resource "aws_instance" "etcds" {
     aws_security_group.etcd.id
   ]
   associate_public_ip_address = true
-  subnet_id                   = local.instance_subnet_id
+  subnet_id                   = element(local.subnet_ids_list, count.index)
 
   lifecycle {
     ignore_changes = [

--- a/examples/test-cluster/main.tf
+++ b/examples/test-cluster/main.tf
@@ -14,13 +14,8 @@ provider "aws" {
   region  = "us-west-1"
 }
 
-provider "github" {
-  owner = "isovalent"
-  token = var.github_token
-}
-
 module "test_vpc" {
-  source = "git::ssh://git@github.com/isovalent/terraform-aws-vpc.git?ref=1.1"
+  source = "git::ssh://git@github.com/isovalent/terraform-aws-vpc.git?ref=v1.9"
   providers = {
     aws = aws.us_west_1
   }

--- a/examples/test-cluster/variables.tf
+++ b/examples/test-cluster/variables.tf
@@ -1,4 +1,0 @@
-variable "github_token" {
-  sensitive = true
-  type      = string
-}


### PR DESCRIPTION
previously the subnet was chosen at "random" for etcd nodes, unfortunately random can also mean "all in the same subnet" which breaks stuff.

Instead this uses the element function with the node_count as an index to always choose a different subnet for nodes.